### PR TITLE
Add missing 'version' param to get WMS legends (ref #11)

### DIFF
--- a/src/L.LayerTreeControl.js
+++ b/src/L.LayerTreeControl.js
@@ -703,6 +703,7 @@ function LeafletProvider(map) {
       url.searchParams.set('request', 'GetLegendGraphic');
       url.searchParams.set('format', 'image/png');
       url.searchParams.set('layer', serviceLayers);
+      url.searchParams.set('version', layer.wmsParams.version);
 
       var legend = {};
       legend.largeImageUrl = `${url.toString()}`;


### PR DESCRIPTION
Here is a one-line fix to add the missing `version` param to WMS `GetLegendGraphic` requests (solves #11). The value passed is the one from Leaflet (default or overridden value).

According to the spec:

> The VERSION parameter is mandatory in requests other than GetCapabilities.

[OpenGIS Web Map Service (WMS) Implementation Specification](https://portal.ogc.org/files/?artifact_id=14416), p. 11.

And some map servers enforce this, as the WMSServer component of an Arcgis server.

It would be awesome if you could merge it and release! :pray: